### PR TITLE
Failed to compile with cc1plus compiler

### DIFF
--- a/src/AWSGreenGrassIoT.cpp
+++ b/src/AWSGreenGrassIoT.cpp
@@ -141,7 +141,7 @@ int AWSGreenGrassIoT::_connect( char * host,  char * rootCA) {
 	connectParams.keepAliveIntervalInSec = 600;
 	connectParams.isCleanSession = true;
 	connectParams.MQTTVersion = MQTT_3_1_1;
-    if (connectParams.clientIDLen = (uint16_t) strlen(_thingName))
+    if (connectParams.clientIDLen == (uint16_t) strlen(_thingName))
 	connectParams.pClientID = _thingName;
 	else
         {


### PR DESCRIPTION
*Issue #, if available:*

I faced the following error and failed to compile.

```
~/arduino-aws-greengrass-iot/src/AWSGreenGrassIoT.cpp: In member function 'int AWSGreenGrassIoT::_connect(char*, char*)':
~/arduino-aws-greengrass-iot/src/AWSGreenGrassIoT.cpp:144:66: error: suggest parentheses around assignment used as truth value [-Werror=parentheses]
     if (connectParams.clientIDLen = (uint16_t) strlen(_thingName))
                                                                  ^
cc1plus: some warnings being treated as errors
exit status 1
Error compiling for board ESP32 Dev Module.
```

Normally, this message looks fine to ignore because it is a warning. 
However, I changed the single equal operator to a double equal operator because it fails to compile. 
It's a very small change...So I created a PR without creating an issue....

- Environment
  - Arduino: 1.8.16
  - OS: Debian GNU/Linux 10 (buster)
  - platform.txt(one part of cpp compiler)
```
compiler.cpp.cmd=avr-g++
compiler.cpp.flags=-c -g -Os {compiler.warning_flags} -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-
```


*Description of changes:*
The following changes have been made. I just added more equals.
I know that some compilers will ignore this warning and compile successfully, but the single equal operator seems to be written in a C-like way.
I think C++ if statements usually use a double equal operator.
uble equal operator.


AWSGreenGrassIoT.cpp:144
```AWSGreenGrassIoT.cpp
    if (connectParams.clientIDLen == (uint16_t) strlen(_thingName))
```

Regards,